### PR TITLE
Allow tags to be set by user and remove default of Automation as a tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,33 +51,48 @@ module "default_vpc" {
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13 |
-| aws | >= 3.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_default_network_acl.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_network_acl) | resource |
+| [aws_default_route_table.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_route_table) | resource |
+| [aws_default_security_group.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_security_group) | resource |
+| [aws_default_subnet.default_azs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_subnet) | resource |
+| [aws_default_vpc.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_vpc) | resource |
+| [aws_default_vpc_dhcp_options.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_vpc_dhcp_options) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| azs | List of AZs to manage using only the letters, not full AZ name | `list(string)` | <pre>[<br>  "a",<br>  "b",<br>  "c",<br>  "d"<br>]</pre> | no |
-| region | AWS Region | `string` | `"us-west-2"` | no |
+| <a name="input_azs"></a> [azs](#input\_azs) | List of AZs to manage using only the letters, not full AZ name | `list(string)` | <pre>[<br>  "a",<br>  "b",<br>  "c",<br>  "d"<br>]</pre> | no |
+| <a name="input_region"></a> [region](#input\_region) | AWS Region | `string` | `"us-west-2"` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags to add to resources | `map(string)` | `{}` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| network\_acl | The Default Network ACL |
-| route\_table | The Default Route Table |
-| security\_group | The Default Security Group |
-| subnets | The Default Subnets |
-| vpc | The Default VPC |
-| vpc\_dhcp\_options | The Default VPC DHCP Options Set |
-
+| <a name="output_network_acl"></a> [network\_acl](#output\_network\_acl) | The Default Network ACL |
+| <a name="output_route_table"></a> [route\_table](#output\_route\_table) | The Default Route Table |
+| <a name="output_security_group"></a> [security\_group](#output\_security\_group) | The Default Security Group |
+| <a name="output_subnets"></a> [subnets](#output\_subnets) | The Default Subnets |
+| <a name="output_vpc"></a> [vpc](#output\_vpc) | The Default VPC |
+| <a name="output_vpc_dhcp_options"></a> [vpc\_dhcp\_options](#output\_vpc\_dhcp\_options) | The Default VPC DHCP Options Set |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Upgrade Paths

--- a/main.tf
+++ b/main.tf
@@ -1,9 +1,8 @@
 resource "aws_default_vpc" "default" {
 
-  tags = {
-    Automation = "terraform"
-    Name       = "default"
-  }
+  tags = merge(var.tags, {
+    Name = "default",
+  })
 }
 
 
@@ -11,10 +10,9 @@ resource "aws_default_subnet" "default_azs" {
   count             = length(var.azs)
   availability_zone = "${var.region}${var.azs[count.index]}"
 
-  tags = {
-    Automation = "terraform"
-    Name       = "Default subnet for ${var.region}${var.azs[count.index]}"
-  }
+  tags = merge(var.tags, {
+    Name = format("Default subnet for %s%s", var.region, var.azs[count.index]),
+  })
 }
 
 resource "aws_default_network_acl" "default" {
@@ -24,10 +22,9 @@ resource "aws_default_network_acl" "default" {
 
   subnet_ids = aws_default_subnet.default_azs.*.id
 
-  tags = {
-    Automation = "terraform"
-    Name       = "default"
-  }
+  tags = merge(var.tags, {
+    Name = "default",
+  })
 }
 
 resource "aws_default_route_table" "default" {
@@ -35,10 +32,9 @@ resource "aws_default_route_table" "default" {
 
   default_route_table_id = aws_default_vpc.default.default_route_table_id
 
-  tags = {
-    Automation = "terraform"
-    Name       = "default"
-  }
+  tags = merge(var.tags, {
+    Name = "default",
+  })
 }
 
 resource "aws_default_security_group" "default" {
@@ -46,17 +42,15 @@ resource "aws_default_security_group" "default" {
 
   vpc_id = aws_default_vpc.default.id
 
-  tags = {
-    Automation = "terraform"
-    Name       = "default"
-  }
+  tags = merge(var.tags, {
+    Name = "default",
+  })
 }
 
 resource "aws_default_vpc_dhcp_options" "default" {
   depends_on = [aws_default_vpc.default]
 
-  tags = {
-    Automation = "terraform"
-    Name       = "default"
-  }
+  tags = merge(var.tags, {
+    Name = "default",
+  })
 }

--- a/variables.tf
+++ b/variables.tf
@@ -3,8 +3,15 @@ variable "region" {
   type        = string
   default     = "us-west-2"
 }
+
 variable "azs" {
   description = "List of AZs to manage using only the letters, not full AZ name"
   type        = list(string)
   default     = ["a", "b", "c", "d"]
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags to add to resources"
+  default     = {}
 }


### PR DESCRIPTION
Users should be able to set their own tags. The existing tag `Automation = "terraform"` can conflict with other tags that folks set like this:

```hcl
provider "aws" {
  region = var.region
  default_tags {
    tags ={
        Automation = "terraform"
    }
  }
}
```

Because `default_tags` are preferred in Terraform >= 1.0 its better if this module doesn't manage any tags except the `Name` tag. Because `Name` has to be set for the default vpc resources or you'll see a change in the plan after adoption.