### PR TITLE
fixes broken aws_region interpolation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,3 @@
-data "aws_region" "current" {}
-
 resource "aws_default_vpc" "default" {
 
   tags = {
@@ -8,14 +6,15 @@ resource "aws_default_vpc" "default" {
   }
 }
 
+data "aws_region" "current" {}
 
 resource "aws_default_subnet" "default_azs" {
   count             = length(var.azs)
-  availability_zone = "${data.aws_region}${var.azs[count.index]}"
+  availability_zone = "${data.aws_region.current.name}${var.azs[count.index]}"
 
   tags = {
     Automation = "terraform"
-    Name       = "Default subnet for ${data.aws_region}${var.azs[count.index]}"
+    Name       = "Default subnet for ${data.aws_region.current.name}${var.azs[count.index]}"
   }
 }
 


### PR DESCRIPTION
Removing the region variable was a breaking change:
```hcl
running "/usr/local/bin/terraform plan -input=false -refresh -out \"/home/atlantis/.atlantis/repos/transcom/transcom-infrasec-gov-nonato/500/default/transcom-gov-milmove-demo/admin-global/transcom-gov-milmove-demo-admin-global-default.tfplan\"" in "/home/atlantis/.atlantis/repos/transcom/transcom-infrasec-gov-nonato/500/default/transcom-gov-milmove-demo/admin-global": exit status 1
╷
│ Error: Unsupported argument
│ 
│   on vpc.tf line 9, in module "default_vpc":
│    9:   region = var.region
│ 
│ An argument named "region" is not expected here.
╵
```
removing the argument causes the following error:
```aws-vault exec transcom-gov-infrasec -- terraform plan
╷
│ Warning: Argument is deprecated
│
│   with module.lambda_builds_us_gov_west_1.aws_s3_bucket.private_bucket,
│   on .terraform/modules/lambda_builds_us_gov_west_1/main.tf line 79, in resource "aws_s3_bucket" "private_bucket":
│   79:   acl           = "private"
│
│ Use the aws_s3_bucket_acl resource instead
╵
╷
│ Error: Invalid reference
│
│   on .terraform/modules/default_vpc/main.tf line 14, in resource "aws_default_subnet" "default_azs":
│   14:   availability_zone = "${data.aws_region}${var.azs[count.index]}"
│
│ The "data" object must be followed by two attribute names: the data source type and the resource name.
╵
╷
│ Error: Invalid reference
│
│   on .terraform/modules/default_vpc/main.tf line 18, in resource "aws_default_subnet" "default_azs":
│   18:     Name       = "Default subnet for ${data.aws_region}${var.azs[count.index]}"
│
│ The "data" object must be followed by two attribute names: the data source type and the resource name.
╵
```

This PR fixes this error. 

I think we should bump the major release version on this for removing the region and having the module interpolate it. 

